### PR TITLE
Added logger for discrete trait subst models.

### DIFF
--- a/src/beast/evolution/substitutionmodel/SVSGeneralSubstitutionModelLogger.java
+++ b/src/beast/evolution/substitutionmodel/SVSGeneralSubstitutionModelLogger.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2015 Tim Vaughan <tgvaughan@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package beast.evolution.substitutionmodel;
+
+import beast.core.BEASTObject;
+import beast.core.Input;
+import beast.core.Loggable;
+import beast.evolution.datatype.UserDataType;
+
+import java.io.PrintStream;
+
+/**
+ * @author Tim Vaughan <tgvaughan@gmail.com>
+ */
+public class SVSGeneralSubstitutionModelLogger extends BEASTObject implements Loggable{
+
+    public Input<SVSGeneralSubstitutionModel> modelInput = new Input<>(
+            "model",
+            "BSSVS general substitution model.",
+            Input.Validate.REQUIRED);
+
+    public Input<UserDataType> dataTypeInput = new Input<>(
+            "dataType",
+            "User data type for the location data.  Used to generate " +
+                    "more readable logs.",
+            Input.Validate.REQUIRED);
+
+    public Input<Boolean> useLocationNamesInput = new Input<>(
+            "useLocationNames",
+            "When true, use full names of locations in log rather than " +
+                    "rate matrix indices.",
+            true);
+
+    protected SVSGeneralSubstitutionModel model;
+
+    public SVSGeneralSubstitutionModelLogger() { }
+
+    @Override
+    public void initAndValidate() throws Exception {
+        model = modelInput.get();
+    }
+
+    /**
+     * If available, retrieve string representation of location, otherwise
+     * simply return the index as a string.
+     *
+     * @param i index of location
+     * @return string representation
+     */
+    private String getLocationString(int i) {
+        if (useLocationNamesInput.get())
+            return dataTypeInput.get().getCode(i);
+        else
+            return String.valueOf(i);
+    }
+
+    @Override
+    public void init(PrintStream out) throws Exception {
+        String mainID = (getID() == null || getID().matches("\\s*"))
+                ? "geoSubstModel"
+                : getID();
+        String relRatePrefix = mainID + ".relGeoRate_";
+
+        UserDataType dataType = dataTypeInput.get();
+
+        for (int i=0; i<model.getStateCount(); i++) {
+            String iStr = getLocationString(i);
+
+            for (int j=model.isSymmetricInput.get() ? i+1 : 0 ; j<model.getStateCount(); j++) {
+                if (j==i)
+                    continue;
+
+                String jStr = getLocationString(j);
+
+                out.print(relRatePrefix + iStr + "_" + jStr + "\t");
+            }
+        }
+    }
+
+    @Override
+    public void log(int nSample, PrintStream out) {
+        int count = 0;
+        for (int i=0; i<model.getStateCount(); i++) {
+            for (int j=model.isSymmetricInput.get() ? i+1 : 0; j<model.getStateCount(); j++) {
+                if (j==i)
+                    continue;
+
+                out.print(model.ratesInput.get().getArrayValue(count)
+                        *model.indicator.get().getArrayValue(count) + "\t");
+
+                count += 1;
+            }
+        }
+    }
+
+    @Override
+    public void close(PrintStream out) { }
+}

--- a/templates/discrete-trait.xml
+++ b/templates/discrete-trait.xml
@@ -88,6 +88,8 @@ suppressInputs='beast.evolution.substitutionmodel.SVSGeneralSubstitutionModel.ra
 
 	 	<operator id='geoMuScaler.c:$(n)' spec='ScaleOperator' scaleFactor="0.9" weight="3" parameter="@traitClockRate.c:$(n)"/>  
 		<operator id="BSSVSoperator.c:$(n)" spec="BitFlipBSSVSOperator" indicator="@rateIndicator.s:$(n)" mu="@traitClockRate.c:$(n)" weight="30"/>
+
+		<log id='geoSubstModelLogger.s:$(n)' spec='SVSGeneralSubstitutionModelLogger' model="@svs.s:$(n)" dataType="@traitDataType.$(n)" useLocationNames="true"/>
 ]]>
 
          <connect srcID='traitedtreeLikelihood.$(n)'              targetID='likelihood' inputName='distribution' if="isInitializing"/>
@@ -109,6 +111,7 @@ suppressInputs='beast.evolution.substitutionmodel.SVSGeneralSubstitutionModel.ra
          <connect srcID='rateIndicator.s:$(n)'                    targetID='tracelog' inputName='log' if='inposterior(traitedtreeLikelihood.$(n)) and $(n)/traitSet!=null and inlikelihood(rateIndicator.s:$(n)) and rateIndicator.s:$(n)/estimate=true'/>
          <connect srcID='relativeGeoRates.s:$(n)'                 targetID='tracelog' inputName='log' if='inposterior(traitedtreeLikelihood.$(n)) and $(n)/traitSet!=null and inlikelihood(relativeGeoRates.s:$(n)) and relativeGeoRates.s:$(n)/estimate=true'/>
          <connect srcID='traitClockRate.c:$(n)'                   targetID='tracelog' inputName='log' if='inposterior(traitedtreeLikelihood.$(n)) and $(n)/traitSet!=null and inlikelihood(traitClockRate.c:$(n)) and traitClockRate.c:$(n)/estimate=true'/>
+		 <connect srcID='geoSubstModelLogger.s:$(n)'              targetID='tracelog' inputName='log' if='inposterior(traitedtreeLikelihood.$(n)) and $(n)/traitSet!=null and inlikelihood(relativeGeoRates.s:$(n)) and relativeGeoRates.s:$(n)/estimate=true'/>
 
          <connect srcID='treeWithTraitLogger.$(n)'                targetID='mcmc' inputName='logger' if='inposterior(traitedtreeLikelihood.$(n)) and $(n)/traitSet!=null'/>
 


### PR DESCRIPTION
The existing setup for discrete trait analyses is to simply log the relative rate and rate indicator parameters.  This is a problem for two reasons:

1. The parameter indices are difficult to interpret when the trait can take many values, especially when symmetric rate matrices are enforced.  (The expressions for determining the row and column of the rate matrix element that correspond to given parameter index require some thought.)

2. I think we should avoid letting users access the rate parameters and the rate indicators separately.  This separation is an inference method detail and it is easy to get the wrong idea by looking at the rate parameter posterior without considering the indicator variables.  We should only ever log the product imo.

This commit includes a logger that logs this product, as well as providing sensible log file headings for the rate matrix elements.  These can either include the actual trait/location names (default):
![names](https://cloud.githubusercontent.com/assets/512538/7852463/18d291ae-0552-11e5-8191-7501ff9cc093.png)

or they can be integer location codes:
![indices](https://cloud.githubusercontent.com/assets/512538/7852466/25e194ee-0552-11e5-96f1-7cf2028ecbcd.png)

I've modified the BEAUti template to include this logger.  I've left in the raw parameter loggers for now, but it would be great if we could remove these at some stage. (See point 2 above.)